### PR TITLE
martini: overlay: Update power_profile.xml

### DIFF
--- a/overlay/OnePlus9RTFrameworks/res/xml/power_profile.xml
+++ b/overlay/OnePlus9RTFrameworks/res/xml/power_profile.xml
@@ -1,282 +1,232 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2016, The Linux Foundation. All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are
-    met:
-        * Redistributions of source code must retain the above copyright
-          notice, this list of conditions and the following disclaimer.
-        * Redistributions in binary form must reproduce the above
-          copyright notice, this list of conditions and the following
-          disclaimer in the documentation and/or other materials provided
-          with the distribution.
-        * Neither the name of The Linux Foundation nor the names of its
-          contributors may be used to endorse or promote products derived
-          from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
-    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
-    ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
-    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-    BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-    WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-    OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
-    IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+**
+** Copyright 2018, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License")
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
 -->
-<!-- project:18097 -->
-
 <device name="Android">
-  <!-- Most values are the incremental current used by a feature,
-       in mA (measured at nominal voltage).
-       The default values are deliberately incorrect dummy values.
-       OEM's must measure and provide actual values before
-       shipping a device.
-       Example real-world values are given in comments, but they
-       are totally dependent on the platform and can vary
-       significantly, so should be measured on the shipping platform
-       with a power meter. -->
-  <item name="none">0</item>
-  <item name="ambient on">35</item>
-  <item name="screen.on.display0">105</item>  <!-- ~200mA -->
-  <item name="screen.full.display0">262</item>  <!-- ~300mA -->
-  <item name="bluetooth.active">46</item> <!-- Bluetooth data transfer, ~10mA -->
-  <item name="bluetooth.on">1.7</item>  <!-- Bluetooth on & connectable, but not connected, ~0.1mA -->
-  <item name="wifi.on">1.8</item>  <!-- ~3mA -->
-  <item name="wifi.active">223</item>  <!-- WIFI data transfer, ~200mA -->
-  <item name="wifi.scan">120</item>  <!-- WIFI network scanning, ~100mA -->
-  <item name="audio">0</item> <!-- ~10mA -->
-  <item name="video">0</item> <!-- ~50mA -->
-  <item name="camera.flashlight">128</item> <!-- Avg. power for camera flash, ~160mA -->
-  <item name="camera.avg">532</item> <!-- Avg. power use of camera in standard usecases, ~550mA -->
-  <item name="gps.on">75</item> <!-- ~50mA -->
-  
-  <item name="audio">16</item> <!-- new add ~10mA -->
-  <item name="video">41</item> <!-- new add ~50mA -->
-  <item name="bluetooth.controller.idle">1.7</item>  <!--new add -->
-  <item name="bluetooth.controller.rx">76</item>  <!--new add  -->
-  <item name="bluetooth.controller.tx">176</item>  <!--new add  -->
-  <item name="bluetooth.controller.voltage">3300</item>  <!--new add -->
+    <!-- All values are in mA except as noted -->
+    <item name="battery.capacity">4500</item>
 
-  <!-- Radio related values. For modems without energy reporting support in firmware, use
-       radio.active, radio.scanning, and radio.on. -->
-  <item name="radio.active">191.5</item> <!-- ~200mA -->
-  <item name="radio.scanning">143.5</item> <!-- cellular radio scanning for signal, ~10mA -->
-  <!-- Current consumed by the radio at different signal strengths, when paging -->
-  <array name="radio.on"> <!-- Strength 0 to BINS-1 delete 1 line-->
-      <value>1</value> <!-- ~2mA -->
-  </array>
+    <!-- Number of cores each CPU cluster contains -->
+    <array name="cpu.clusters.cores">
+        <value>4</value> <!-- Cluster 0 has 6 cores (cpu0, cpu1, cpu2, cpu3) -->
+        <value>3</value> <!-- Cluster 1 has 2 cores (cpu4, cpu5, cpu6) -->
+        <value>1</value> <!-- Cluster 2 has 1 core (cpu7) -->
+    </array>
 
+    <!-- Power consumption when CPU is awaken -->
+    <item name="cpu.awake">15.68</item>
+    <!-- Additional power consumption when CPU is in a kernel idle loop -->
+    <item name="cpu.idle">6.5</item>
 
-  <!-- Radio related values. For modems WITH energy reporting support in firmware, use
-       modem.controller.idle, modem.controller.tx, modem.controller.rx, modem.controller.voltage.
-       -->
-  <item name="modem.controller.idle">1</item>
-  <item name="modem.controller.rx">200.8</item>
-  <array name="modem.controller.tx">
+    <!-- Different CPU speeds as reported in
+         /sys/devices/system/cpu/cpu0/cpufreq/stats/scaling_available_frequencies -->
+    <array name="cpu.core_speeds.cluster0">
+        <value>300000</value>   <!-- 300 MHz CPU speed -->
+        <value>403200</value>   <!-- 403.2 MHz CPU speed -->
+        <value>518400</value>  <!-- 499.2 MHz CPU speed -->
+        <value>614400</value>  <!-- 576 MHz CPU speed -->
+        <value>691200</value>  <!-- 672 MHz CPU speed -->
+        <value>787200</value>  <!-- 768 MHz CPU speed -->
+        <value>883200</value>  <!-- 844.8 MHz CPU speed -->
+        <value>979200</value>  <!-- 940.8 MHz CPU speed -->
+        <value>1075200</value>  <!-- 1036.8 MHz CPU speed -->
+        <value>1171200</value>  <!-- 1113.6 MHz CPU speed -->
+        <value>1248000</value>  <!-- 1209.6 MHz CPU speed -->
+        <value>1344000</value>  <!-- 1305.6 MHz CPU speed -->
+        <value>1420800</value>  <!-- 1382.4 MHz CPU speed -->
+        <value>1516800</value>  <!-- 1478.4 MHz CPU speed -->
+        <value>1612800</value>  <!-- 1555.2 MHz CPU speed -->
+        <value>1708800</value>  <!-- 1555.2 MHz CPU speed -->
+        <value>1804800</value>  <!-- 1632 MHz CPU speed -->
+    </array>
+
+    <!-- Different CPU speeds as reported in
+         /sys/devices/system/cpu/cpu4/cpufreq/stats/scaling_available_frequencies -->
+    <array name="cpu.core_speeds.cluster1">
+        <value>710400</value>  <!-- 710.4 MHz CPU speed -->
+        <value>825600</value>  <!-- 825.6 MHz CPU speed -->
+        <value>940800</value>  <!-- 940.8 MHz CPU speed -->
+        <value>1056000</value>  <!-- 1056 MHz CPU speed -->
+        <value>1171200</value>  <!-- 1171.2 MHz CPU speed -->
+        <value>1286400</value>  <!-- 1286.4 MHz CPU speed -->
+        <value>1382400</value>  <!-- 1401.6 MHz CPU speed -->
+        <value>1478400</value>  <!-- 1497.6 MHz CPU speed -->
+        <value>1574400</value>  <!-- 1612.8 MHz CPU speed -->
+        <value>1670400</value>  <!-- 1708.8 MHz CPU speed -->
+        <value>1766400</value>  <!-- 1804.8 MHz CPU speed -->
+        <value>1862400</value>  <!-- 1920 MHz CPU speed -->
+        <value>1958400</value>  <!-- 2016 MHz CPU speed -->
+        <value>2054400</value>  <!-- 2131.2 MHz CPU speed -->
+        <value>2150400</value>  <!-- 2227.2 MHz CPU speed -->
+        <value>2246400</value>  <!-- 2323.2 MHz CPU speed -->
+        <value>2342400</value>  <!-- 2419.2 MHz CPU speed -->
+        <value>2419200</value>  <!-- 2419.2 MHz CPU speed -->
+    </array>
+
+    <!-- Different CPU speeds as reported in
+         /sys/devices/system/cpu/cpu4/cpufreq/stats/scaling_available_frequencies -->
+    <array name="cpu.core_speeds.cluster2">
+        <value>844800</value>  <!-- 825.6 MHz CPU speed -->
+        <value>960000</value>  <!-- 940.8 MHz CPU speed -->
+        <value>1075200</value>  <!-- 1056 MHz CPU speed -->
+        <value>1190400</value>  <!-- 1171.2 MHz CPU speed -->
+        <value>1305600</value>  <!-- 1286.4 MHz CPU speed -->
+        <value>1401600</value>  <!-- 1401.6 MHz CPU speed -->
+        <value>1516800</value>  <!-- 1497.6 MHz CPU speed -->
+        <value>1632000</value>  <!-- 1612.8 MHz CPU speed -->
+        <value>1747200</value>  <!-- 1708.8 MHz CPU speed -->
+        <value>1862400</value>  <!-- 1804.8 MHz CPU speed -->
+        <value>1977600</value>  <!-- 1920 MHz CPU speed -->
+        <value>2073600</value>  <!-- 2016 MHz CPU speed -->
+        <value>2169600</value>  <!-- 2131.2 MHz CPU speed -->
+        <value>2265600</value>  <!-- 2227.2 MHz CPU speed -->
+        <value>2361600</value>  <!-- 2323.2 MHz CPU speed -->
+        <value>2457600</value>  <!-- 2419.2 MHz CPU speed -->
+        <value>2553600</value>  <!-- 2534.4 MHz CPU speed -->
+        <value>2649600</value>  <!-- 2649.6 MHz CPU speed -->
+        <value>2745600</value>  <!-- 2745.6 MHz CPU speed -->
+        <value>2841600</value>  <!-- 2841.6 MHz CPU speed -->
+        <value>3187200</value>  <!-- 3187.2 MHz CPU speed -->
+    </array>
+
+    <!-- Additional power used by a CPU core from cluster 0 when running at
+         different speeds, excluding cluster and active cost -->
+    <array name="cpu.core_power.cluster0">
+        <value>30</value>  <!-- ~35mA -->
+        <value>42</value>  <!-- ~35mA -->
+        <value>53</value>  <!-- ~40mA -->
+        <value>64</value>  <!-- ~50mA -->
+        <value>71</value>  <!-- ~50mA -->
+        <value>82</value>  <!-- ~50mA -->
+        <value>95</value>  <!-- ~60mA -->
+        <value>108</value>  <!-- ~60mA -->
+        <value>122</value>  <!-- ~60mA -->
+        <value>130</value>  <!-- ~70mA -->
+        <value>142</value>  <!-- ~70mA -->
+        <value>153</value>  <!-- ~70mA -->
+        <value>166</value>  <!-- ~80mA -->
+        <value>180</value>  <!-- ~80mA -->
+        <value>191</value>  <!-- ~90mA -->
+        <value>204</value>  <!-- ~90mA -->
+        <value>211</value>  <!-- ~90mA -->
+    </array>
+
+    <!-- Additional power used by a CPU core from cluster 1 when running at
+         different speeds, excluding cluster and active cost -->
+    <array name="cpu.core_power.cluster1">
+        <value>48</value>  <!-- ~60mA -->
+        <value>57</value>  <!-- ~60mA -->
+        <value>63</value>  <!-- ~80mA -->
+        <value>71</value>  <!-- ~80mA -->
+        <value>81</value>  <!-- ~100mA -->
+        <value>94</value>  <!-- ~100mA -->
+        <value>109</value>  <!-- ~120mA -->
+        <value>125</value>  <!-- ~120mA -->
+        <value>140</value>  <!-- ~140mA -->
+        <value>156</value>  <!-- ~140mA -->
+        <value>165</value>  <!-- ~140mA -->
+        <value>182</value>  <!-- ~170mA -->
+        <value>200</value>  <!-- ~170mA -->
+        <value>215</value>  <!-- ~190mA -->
+        <value>230</value>  <!-- ~190mA -->
+        <value>245</value>  <!-- ~200mA -->
+        <value>260</value>  <!-- ~200mA -->
+        <value>280</value>  <!-- ~200mA -->
+    </array>
+
+    <!-- Additional power used by a CPU core from cluster 2 when running at
+         different speeds, excluding cluster and active cost -->
+    <array name="cpu.core_power.cluster1">
+        <value>51</value>  <!-- ~60mA -->
+        <value>58</value>  <!-- ~60mA -->
+        <value>67</value>  <!-- ~80mA -->
+        <value>75</value>  <!-- ~80mA -->
+        <value>86</value>  <!-- ~100mA -->
+        <value>97</value>  <!-- ~100mA -->
+        <value>105</value>  <!-- ~120mA -->
+        <value>114</value>  <!-- ~120mA -->
+        <value>128</value>  <!-- ~140mA -->
+        <value>137</value>  <!-- ~140mA -->
+        <value>146</value>  <!-- ~140mA -->
+        <value>164</value>  <!-- ~170mA -->
+        <value>176</value>  <!-- ~170mA -->
+        <value>190</value>  <!-- ~190mA -->
+        <value>201</value>  <!-- ~190mA -->
+        <value>220</value>  <!-- ~200mA -->
+        <value>235</value>  <!-- ~170mA -->
+        <value>260</value>  <!-- ~190mA -->
+        <value>291</value>  <!-- ~190mA -->
+        <value>325</value>  <!-- ~200mA -->
+    </array>
+
+    <!-- Additional power used when screen is ambient mode -->
+    <item name="ambient.on.display0">35</item>
+
+    <!-- Additional power used when screen is turned on at minimum brightness -->
+    <item name="screen.on.display0">105</item>
+    <!-- Additional power used when screen is at maximum brightness, compared to
+         screen at minimum brightness -->
+    <item name="screen.full.display0">262</item>
+
+    <!-- Average power used by the camera flash module when on -->
+    <item name="camera.flashlight">128</item>
+    <!-- Average power use by the camera subsystem for a typical camera
+         application. Intended as a rough estimate for an application running a
+         preview and capturing approximately 10 full-resolution pictures per
+         minute. -->
+    <item name="camera.avg">532</item>
+
+    <!-- Additional power used when video is playing -->
+    <item name="video">16</item>
+    <!-- Additional power used when audio is playing -->
+    <item name="audio">41</item>
+
+    <!-- Cellular modem related values.-->
+    <item name="modem.controller.sleep">0</item>
+    <item name="modem.controller.idle">1</item>
+    <item name="modem.controller.rx">200.8</item>
+    <array name="modem.controller.tx"> <!-- Strength 0 to 4 -->
       <value>176.4</value>
       <value>246.8</value>
       <value>323.3</value>
       <value>484.6</value>
       <value>646.8</value>
-  </array>
-  <item name="modem.controller.voltage">800</item>
+    </array>
+    <item name="modem.controller.voltage">800</item>
 
-  <!-- A list of heterogeneous CPU clusters, where the value for each cluster represents the
-       number of CPU cores for that cluster.
+    <!-- GPS related values.-->
+    <item name="gps.on">75</item>
 
-       Ex:
-       <array name="cpu.clusters.cores">
-         <value>4</value> // cluster 0 has cpu0, cpu1, cpu2, cpu3
-         <value>2</value> // cluster 1 has cpu4, cpu5
-       </array> -->
-  <array name="cpu.clusters.cores">
-      <value>4</value> <!-- cluster 0 has cpu0, cpu1, cpu2, cpu3 -->
-      <value>3</value> <!-- cluster 1 has cpu4, cpu5, cpu6 -->
-      <value>1</value> <!-- cluster 2 has cpu7 -->
-  </array>
+    <!-- WiFi related values.-->
+    <item name="wifi.on">1.8</item>  <!-- ~3mA -->
+    <item name="wifi.active">223</item>  <!-- WIFI data transfer, ~200mA -->
+    <item name="wifi.scan">120</item>  <!-- WIFI network scanning, ~100mA -->
 
-    <!-- Different CPU speeds for cluster 0 as reported in
-       /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state.
+    <!-- Bluetooth related values.-->
+    <item name="bluetooth.active">46</item> <!-- Bluetooth data transfer, ~10mA -->
+    <item name="bluetooth.on">1.7</item>  <!-- Bluetooth on & connectable, but not connected, ~0.1mA -->
 
-       There must be one of these for each cluster, labeled:
-       cpu.speeds.cluster0, cpu.speeds.cluster1, etc... -->
-  <array name="cpu.core_speeds.cluster0">
-      <value>300000</value>   <!-- 300  MHz CPU speed -->
-      <value>403200 </value>   <!-- 403.2  MHz CPU speed -->
-      <value>518400 </value>  <!-- 499.2 MHz CPU speed -->
-      <value>614400 </value>  <!-- 576 MHz CPU speed -->
-      <value>691200 </value>  <!-- 672 MHz CPU speed -->
-      <value>787200 </value>  <!-- 768 MHz CPU speed -->
-      <value>883200 </value>  <!-- 844.8 MHz CPU speed -->
-      <value>979200 </value>  <!-- 940.8 MHz CPU speed -->
-      <value>1075200 </value>  <!-- 1036.8 MHz CPU speed -->
-      <value>1171200  </value>  <!-- 1113.6 MHz CPU speed -->
-      <value>1248000   </value>  <!-- 1209.6 MHz CPU speed -->
-      <value>1344000  </value>  <!-- 1305.6 MHz CPU speed -->
-      <value>1420800  </value>  <!-- 1382.4 MHz CPU speed -->
-      <value>1516800  </value>  <!-- 1478.4 MHz CPU speed -->
-      <value>1612800  </value>  <!-- 1555.2 MHz CPU speed -->
-      <value>1708800  </value>  <!-- 1555.2 MHz CPU speed -->
-      <value>1804800  </value>  <!-- 1632 MHz CPU speed -->
-  </array>
-
-  <array name="cpu.core_speeds.cluster1">
-      <value>710400 </value>  <!-- 710.4  MHz CPU speed -->
-      <value>825600 </value>  <!-- 825.6  MHz CPU speed -->
-      <value>940800 </value>  <!-- 940.8  MHz CPU speed -->
-      <value>1056000 </value>  <!-- 1056  MHz CPU speed -->
-      <value>1171200 </value>  <!-- 1171.2  MHz CPU speed -->
-      <value>1286400 </value>  <!-- 1286.4  MHz CPU speed -->
-      <value>1382400 </value>  <!-- 1401.6  MHz CPU speed -->
-      <value>1478400 </value>  <!-- 1497.6  MHz CPU speed -->
-      <value>1574400 </value>  <!-- 1612.8  MHz CPU speed -->
-      <value>1670400 </value>  <!-- 1708.8  MHz CPU speed -->
-      <value>1766400 </value>  <!-- 1804.8  MHz CPU speed -->
-      <value>1862400 </value>  <!-- 1920  MHz CPU speed -->
-      <value>1958400 </value>  <!-- 2016  MHz CPU speed -->
-      <value>2054400  </value>  <!-- 2131.2  MHz CPU speed -->
-      <value>2150400  </value>  <!-- 2227.2  MHz CPU speed -->
-      <value>2246400  </value>  <!-- 2323.2  MHz CPU speed -->
-      <value>2342400 </value>  <!-- 2419.2  MHz CPU speed -->
-      <value>2419200 </value>  <!-- 2419.2  MHz CPU speed -->
-  </array>
-
-  <array name="cpu.core_speeds.cluster2">
-      <value>844800 </value>  <!-- 825.6  MHz CPU speed -->
-      <value>960000 </value>  <!-- 940.8  MHz CPU speed -->
-      <value>1075200 </value>  <!-- 1056  MHz CPU speed -->
-      <value>1190400 </value>  <!-- 1171.2  MHz CPU speed -->
-      <value>1305600 </value>  <!-- 1286.4  MHz CPU speed -->
-      <value>1401600 </value>  <!-- 1401.6  MHz CPU speed -->
-      <value>1516800 </value>  <!-- 1497.6  MHz CPU speed -->
-      <value>1632000 </value>  <!-- 1612.8  MHz CPU speed -->
-      <value>1747200 </value>  <!-- 1708.8  MHz CPU speed -->
-      <value>1862400 </value>  <!-- 1804.8  MHz CPU speed -->
-      <value>1977600 </value>  <!-- 1920  MHz CPU speed -->
-      <value>2073600 </value>  <!-- 2016  MHz CPU speed -->
-      <value>2169600  </value>  <!-- 2131.2  MHz CPU speed -->
-      <value>2265600  </value>  <!-- 2227.2  MHz CPU speed -->
-      <value>2361600  </value>  <!-- 2323.2  MHz CPU speed -->
-      <value>2457600 </value>  <!-- 2419.2  MHz CPU speed -->
-      <value>2553600   </value>  <!-- 2534.4  MHz CPU speed -->
-      <value>2649600   </value>  <!-- 2649.6  MHz CPU speed -->
-      <value>2745600   </value>  <!-- 2745.6  MHz CPU speed -->
-      <value>2841600 </value>  <!-- 2841.6  MHz CPU speed -->
-      <value>3187200 </value>  <!-- 3187.2  MHz CPU speed -->
-  </array>
-
-  <!-- Current at each CPU speed for cluster 0, as per 'cpu.speeds.cluster0'.
-       Like cpu.speeds.cluster0, there must be one of these present for
-       each heterogeneous CPU cluster. -->
-  <array name="cpu.core_power.cluster0">
-      <value>30</value>  <!-- ~35mA -->
-      <value>42</value>  <!-- ~35mA -->
-      <value>53</value>  <!-- ~40mA -->
-      <value>64</value>  <!-- ~50mA -->
-      <value>71</value>  <!-- ~50mA -->
-      <value>82</value>  <!-- ~50mA -->
-      <value>95</value>  <!-- ~60mA -->
-      <value>108</value>  <!-- ~60mA -->
-      <value>122</value>  <!-- ~60mA -->
-      <value>130</value>  <!-- ~70mA -->
-      <value>142</value>  <!-- ~70mA -->
-      <value>153</value>  <!-- ~70mA -->
-      <value>166</value>  <!-- ~80mA -->
-      <value>180</value>  <!-- ~80mA -->
-      <value>191</value>  <!-- ~90mA -->
-      <value>204</value>  <!-- ~90mA -->
-      <value>211</value>  <!-- ~90mA -->
-  </array>
-
-  <!-- Current at each CPU speed for cluster 1, as per 'cpu.speeds.cluster1'.
-       Like cpu.speeds.cluster1, there must be one of these present for
-       each heterogeneous CPU cluster. -->
-  <array name="cpu.core_power.cluster1">
-      <value>48</value>  <!-- ~60mA -->
-      <value>57</value>  <!-- ~60mA -->
-      <value>63</value>  <!-- ~80mA -->
-      <value>71</value>  <!-- ~80mA -->
-      <value>81</value>  <!-- ~100mA -->
-      <value>94</value>  <!-- ~100mA -->
-      <value>109</value>  <!-- ~120mA -->
-      <value>125</value>  <!-- ~120mA -->
-      <value>140</value>  <!-- ~140mA -->
-      <value>156</value>  <!-- ~140mA -->
-      <value>165</value>  <!-- ~140mA -->
-      <value>182</value>  <!-- ~170mA -->
-      <value>200</value>  <!-- ~170mA -->
-      <value>215</value>  <!-- ~190mA -->
-      <value>230</value>  <!-- ~190mA -->
-      <value>245</value>  <!-- ~200mA -->
-      <value>260</value>  <!-- ~200mA -->
-      <value>280</value>  <!-- ~200mA -->
-  </array>
-
-  <!-- Current at each CPU speed for cluster 2, as per 'cpu.speeds.cluster2'.
-       Like cpu.speeds.cluster2, there must be one of these present for
-       each heterogeneous CPU cluster. -->
-  <array name="cpu.core_power.cluster1">
-      <value>51</value>  <!-- ~60mA -->
-      <value>58</value>  <!-- ~60mA -->
-      <value>67</value>  <!-- ~80mA -->
-      <value>75</value>  <!-- ~80mA -->
-      <value>86</value>  <!-- ~100mA -->
-      <value>97</value>  <!-- ~100mA -->
-      <value>105</value>  <!-- ~120mA -->
-      <value>114</value>  <!-- ~120mA -->
-      <value>128</value>  <!-- ~140mA -->
-      <value>137</value>  <!-- ~140mA -->
-      <value>146</value>  <!-- ~140mA -->
-      <value>164</value>  <!-- ~170mA -->
-      <value>176</value>  <!-- ~170mA -->
-      <value>190</value>  <!-- ~190mA -->
-      <value>201</value>  <!-- ~190mA -->
-      <value>220</value>  <!-- ~200mA -->
-      <value>235</value>  <!-- ~170mA -->
-      <value>260</value>  <!-- ~190mA -->
-      <value>291</value>  <!-- ~190mA -->
-      <value>325</value>  <!-- ~200mA -->
-  </array>
-
-  <!-- Current when CPU is awake -->
-  <item name="cpu.awake">15.68</item>
-  <!-- Current when CPU is idle -->
-  <item name="cpu.idle">6.5</item>
-
-  <!-- Memory bandwidth power values in mA at the rail. There must be one value
-       for each bucket defined in the device tree. -->
-  <array name="memory.bandwidths">
-    <value>22.7</value> <!-- mA for bucket: 100mb/s-1.5 GB/s memory bandwidth -->
-  </array>
-
-  <!-- This is the battery capacity in mAh (measured at nominal voltage) -->
-  <item name="battery.capacity">4500</item>
-
-  <!-- Wifi related values. -->
-  <!-- Idle Receive current for wifi radio in mA. 0 by default-->
-  <item name="wifi.controller.idle">1.4</item>
-  <!-- Rx current for wifi radio in mA. 0 by default-->
-  <item name="wifi.controller.rx">177</item>
-  <!-- Tx current for wifi radio in mA. 0 by default-->
-  <item name="wifi.controller.tx">269</item>
-  <!-- Current at each of the wifi Tx levels in mA. The number of tx levels varies per device
-       and is available only of wifi chipsets which support the tx level reporting. Use
-        wifi.tx for other chipsets. none by default -->
-  <array name="wifi.controller.tx_levels"> <!-- mA -->
-  </array>
-  <!-- Operating volatage for wifi radio in mV. 0 by default-->
-  <item name="wifi.controller.voltage">3300</item>
-
-  <array name="wifi.batchedscan"> <!-- mA -->
-    <value>.0002</value> <!-- 1-8/hr -->
-    <value>.002</value>  <!-- 9-64/hr -->
-    <value>.02</value>   <!-- 65-512/hr -->
-    <value>.2</value>    <!-- 513-4,096/hr -->
-    <value>2</value>    <!-- 4097-/hr -->
-  </array>
+    <!-- Idle Receive current for wifi radio in mA.-->
+    <item name="wifi.controller.idle">1.4</item>
+    <!-- Rx current for wifi radio in mA.-->
+    <item name="wifi.controller.rx">177</item>
+    <!-- Tx current for wifi radio in mA-->
+    <item name="wifi.controller.tx">269</item>
+    <!-- Operating voltage for wifi radio in mV.-->
+    <item name="wifi.controller.voltage">3300</item>
 
 </device>


### PR DESCRIPTION
To match with code of conduct and AOSP. Some things have been removed due to their defaults in frameworks_base :shrug:
Also fixes ambient.on.display0 (it was listed as "ambient on")

* Now matches AOSP power_profile
* Dropped default things which specified in frameworks_base